### PR TITLE
Update M-FKE & add hibernation state

### DIFF
--- a/commons/api_path.go
+++ b/commons/api_path.go
@@ -55,11 +55,12 @@ var ApiPath = struct {
 	DedicatedFKEUpgradeVersion func(vpcId string, clusterId string) string
 	DedicatedFKEManagement     func(vpcId string, clusterId string) string
 
-	ManagedFKEList   func(vpcId string, page int, pageSize int, infraType string) string
-	ManagedFKEGet    func(vpcId string, platform string, clusterId string) string
-	ManagedFKEDelete func(vpcId string, platform string, clusterName string) string
-	ManagedFKECreate func(vpcId string, platform string) string
-	GetFKEOSVersion  func(vpcId string, platform string) string
+	ManagedFKEList      func(vpcId string, page int, pageSize int, infraType string) string
+	ManagedFKEGet       func(vpcId string, platform string, clusterId string) string
+	ManagedFKEDelete    func(vpcId string, platform string, clusterName string) string
+	ManagedFKECreate    func(vpcId string, platform string) string
+	ManagedFKEHibernate func(vpcId, platform, clusterId string, isWakeup bool) string
+	GetFKEOSVersion     func(vpcId string, platform string) string
 
 	// Object Storage
 	// Common
@@ -259,6 +260,17 @@ var ApiPath = struct {
 		return fmt.Sprintf(
 			"/v1/xplat/fke/vpc/%s/m-fke/%s/get-shoot-specific/shoots/%s",
 			vpcId, platform, clusterId,
+		)
+	},
+	ManagedFKEHibernate: func(vpcId, platform, clusterId string, isWakeup bool) string {
+		action := "hibernate"
+		if isWakeup {
+			action = "wakeup"
+		}
+
+		return fmt.Sprintf(
+			"/v1/xplat/fke/vpc/%s/m-fke/%s/hibernation-cluster/shoots/%s/%s",
+			vpcId, platform, clusterId, action,
 		)
 	},
 	GetFKEOSVersion: func(vpcId string, platform string) string {

--- a/fptcloud/dfke/resource_dfke.go
+++ b/fptcloud/dfke/resource_dfke.go
@@ -69,7 +69,7 @@ func (r *resourceDedicatedKubernetesEngine) Create(ctx context.Context, request 
 		return
 	}
 
-	errorResponse := checkForError(a)
+	errorResponse := CheckForError(a)
 	if errorResponse != nil {
 		response.Diagnostics.Append(errorResponse)
 		return
@@ -448,7 +448,7 @@ func (r *resourceDedicatedKubernetesEngine) internalRead(ctx context.Context, cl
 	return &d, nil
 }
 
-func checkForError(a []byte) *diag2.ErrorDiagnostic {
+func CheckForError(a []byte) *diag2.ErrorDiagnostic {
 	var re map[string]interface{}
 	err := json.Unmarshal(a, &re)
 	if err != nil {
@@ -640,7 +640,7 @@ func (r *resourceDedicatedKubernetesEngine) upgradeVersion(ctx context.Context, 
 			return &d
 		}
 
-		if diagErr2 := checkForError(a); diagErr2 != nil {
+		if diagErr2 := CheckForError(a); diagErr2 != nil {
 			return diagErr2
 		}
 
@@ -695,7 +695,7 @@ func (r *resourceDedicatedKubernetesEngine) manage(state *dedicatedKubernetesEng
 		return &d
 	}
 
-	if diagErr2 := checkForError(a); diagErr2 != nil {
+	if diagErr2 := CheckForError(a); diagErr2 != nil {
 		return diagErr2
 	}
 

--- a/fptcloud/dfke/resource_dfke_state.go
+++ b/fptcloud/dfke/resource_dfke_state.go
@@ -148,7 +148,7 @@ func (r *resourceDedicatedKubernetesEngineState) Update(ctx context.Context, req
 		return
 	}
 
-	if diagErr2 := checkForError(a); diagErr2 != nil {
+	if diagErr2 := CheckForError(a); diagErr2 != nil {
 		response.Diagnostics.Append(diagErr2)
 		return
 	}

--- a/fptcloud/edge_gateway/datasource_edge_gateway.go
+++ b/fptcloud/edge_gateway/datasource_edge_gateway.go
@@ -66,7 +66,7 @@ func (d *datasourceEdgeGateway) Read(ctx context.Context, request datasource.Rea
 		return
 	}
 
-	var foundEdgeGateway edgeGatewayData
+	var foundEdgeGateway EdgeGatewayData
 	for _, edgeGateway := range *edgeGatewayList {
 		if edgeGateway.Name == state.Name.ValueString() {
 			foundEdgeGateway = edgeGateway
@@ -112,7 +112,7 @@ func (d *datasourceEdgeGateway) Configure(ctx context.Context, request datasourc
 	d.client = client
 }
 
-func (d *datasourceEdgeGateway) internalRead(_ context.Context, state *edge_gateway) (*[]edgeGatewayData, error) {
+func (d *datasourceEdgeGateway) internalRead(_ context.Context, state *edge_gateway) (*[]EdgeGatewayData, error) {
 	vpcId := state.VpcId.ValueString()
 
 	res, err := d.client.SendGetRequest(common.ApiPath.EdgeGatewayList(vpcId))
@@ -121,7 +121,7 @@ func (d *datasourceEdgeGateway) internalRead(_ context.Context, state *edge_gate
 		return nil, err
 	}
 
-	var r edgeGatewayResponse
+	var r EdgeGatewayResponse
 	if err = json.Unmarshal(res, &r); err != nil {
 		return nil, err
 	}
@@ -136,13 +136,13 @@ type edge_gateway struct {
 	VpcId         types.String `tfsdk:"vpc_id"`
 }
 
-type edgeGatewayData struct {
+type EdgeGatewayData struct {
 	Id            string `json:"id"`
 	Name          string `json:"name"`
 	EdgeGatewayId string `json:"edge_gateway_id"`
 	VpcId         string `json:"vpc_id"`
 }
 
-type edgeGatewayResponse struct {
-	Data []edgeGatewayData `json:"data"`
+type EdgeGatewayResponse struct {
+	Data []EdgeGatewayData `json:"data"`
 }

--- a/fptcloud/mfke/mfke_descriptions.go
+++ b/fptcloud/mfke/mfke_descriptions.go
@@ -21,6 +21,8 @@ var descriptions = map[string]string{
 	"worker_type":           "Worker flavor ID",
 	"network_name":          "Subnet name",
 	"network_id":            "Subnet ID",
+	"network_overlay":       "Whether to encapsulate pod traffic between different subnets or same subnet",
+	"edge_gateway_id":       "Edge gateway ID, in the format of urn:vcloud:gateway:<uuid>",
 	"worker_disk_size":      "Worker disk size",
 	"scale_min":             "Minimum number of nodes for autoscaling",
 	"scale_max":             "Maximum number of nodes for autoscaling",

--- a/fptcloud/mfke/resource_mfke.go
+++ b/fptcloud/mfke/resource_mfke.go
@@ -772,7 +772,7 @@ func (r *resourceManagedKubernetesEngine) getOsVersion(ctx context.Context, vers
 	diag := diag2.NewErrorDiagnostic("Error finding OS version", "K8s version "+version+" not found")
 	return nil, &diag
 }
-func (r *resourceManagedKubernetesEngine) getEdgeGateway(ctx context.Context, edgeId string, vpcId string) (*fptcloud_edge_gateway.EdgeGatewayData, *diag2.ErrorDiagnostic) {
+func (r *resourceManagedKubernetesEngine) getEdgeGateway(_ context.Context, edgeId string, vpcId string) (*fptcloud_edge_gateway.EdgeGatewayData, *diag2.ErrorDiagnostic) {
 	res, err := r.client.SendGetRequest(commons.ApiPath.EdgeGatewayList(vpcId))
 
 	if err != nil {

--- a/fptcloud/mfke/resource_mfke_powerstate.go
+++ b/fptcloud/mfke/resource_mfke_powerstate.go
@@ -1,0 +1,249 @@
+package fptcloud_mfke
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	diag2 "github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+	"strings"
+	"terraform-provider-fptcloud/commons"
+	fptcloud_dfke "terraform-provider-fptcloud/fptcloud/dfke"
+)
+
+var (
+	_ resource.Resource                = &resourceManagedKubernetesEngineState{}
+	_ resource.ResourceWithConfigure   = &resourceManagedKubernetesEngineState{}
+	_ resource.ResourceWithImportState = &resourceManagedKubernetesEngineState{}
+)
+
+type resourceManagedKubernetesEngineState struct {
+	//client        *commons.Client
+	mfkeClient    *MfkeApiClient
+	tenancyClient *fptcloud_dfke.TenancyApiClient
+}
+
+func NewResourceDedicatedKubernetesEngineState() resource.Resource {
+	return &resourceManagedKubernetesEngineState{}
+}
+
+func (r *resourceManagedKubernetesEngineState) ImportState(ctx context.Context, request resource.ImportStateRequest, response *resource.ImportStateResponse) {
+	pieces := strings.Split(request.ID, "/")
+	if len(pieces) != 2 {
+		response.Diagnostics.Append(diag2.NewErrorDiagnostic("Wrong import format", "Expected import ID in format vpc_id/cluster_name"))
+	}
+
+	vpcId := pieces[0]
+	clusterName := pieces[1]
+
+	tflog.Info(ctx, "Importing state for VPC "+vpcId+", cluster "+clusterName)
+
+	var state managedKubernetesEngineState
+	state.Id = types.StringValue(clusterName)
+	state.VpcId = types.StringValue(vpcId)
+
+	err := r.internalRead(ctx, clusterName, &state)
+	if err != nil {
+		response.Diagnostics.Append(diag2.NewErrorDiagnostic("Error calling API", err.Error()))
+		return
+	}
+
+	diags := response.State.Set(ctx, &state)
+	response.Diagnostics.Append(diags...)
+	if response.Diagnostics.HasError() {
+		return
+	}
+}
+
+func (r *resourceManagedKubernetesEngineState) Metadata(ctx context.Context, request resource.MetadataRequest, response *resource.MetadataResponse) {
+	response.TypeName = request.ProviderTypeName + "_managed_kubernetes_engine_v1_state"
+}
+
+func (r *resourceManagedKubernetesEngineState) Schema(ctx context.Context, request resource.SchemaRequest, response *resource.SchemaResponse) {
+	response.Schema = schema.Schema{
+		Description: "Manage managed FKE cluster hibernation state",
+		Attributes: map[string]schema.Attribute{
+			"id": schema.StringAttribute{
+				Required:      true,
+				Description:   "Cluster ID, as seen on portal.",
+				PlanModifiers: forceNewPlanModifiersString,
+			},
+			"vpc_id": schema.StringAttribute{
+				Required:      true,
+				Description:   "VPC ID (an UUID string)",
+				PlanModifiers: forceNewPlanModifiersString,
+			},
+			"is_running": schema.BoolAttribute{
+				Required:    true,
+				Description: "Whether the cluster runs",
+			},
+		},
+	}
+}
+
+func (r *resourceManagedKubernetesEngineState) Create(ctx context.Context, request resource.CreateRequest, response *resource.CreateResponse) {
+	var state managedKubernetesEngineState
+	diags := request.Plan.Get(ctx, &state)
+
+	response.Diagnostics.Append(diags...)
+	if response.Diagnostics.HasError() {
+		return
+	}
+
+	if err := r.internalRead(ctx, state.Id.ValueString(), &state); err != nil {
+		response.Diagnostics.Append(diag2.NewErrorDiagnostic("Error reading cluster state", err.Error()))
+		return
+	}
+
+	diags = response.State.Set(ctx, &state)
+	response.Diagnostics.Append(diags...)
+	if response.Diagnostics.HasError() {
+		return
+	}
+}
+
+func (r *resourceManagedKubernetesEngineState) Read(ctx context.Context, request resource.ReadRequest, response *resource.ReadResponse) {
+	var state managedKubernetesEngineState
+	diags := request.State.Get(ctx, &state)
+
+	response.Diagnostics.Append(diags...)
+	if response.Diagnostics.HasError() {
+		return
+	}
+
+	if err := r.internalRead(ctx, state.Id.ValueString(), &state); err != nil {
+		response.Diagnostics.Append(diag2.NewErrorDiagnostic("Error reading cluster state", err.Error()))
+		return
+	}
+
+	diags = response.State.Set(ctx, &state)
+	response.Diagnostics.Append(diags...)
+	if response.Diagnostics.HasError() {
+		return
+	}
+}
+
+func (r *resourceManagedKubernetesEngineState) Update(ctx context.Context, request resource.UpdateRequest, response *resource.UpdateResponse) {
+	var state managedKubernetesEngineState
+	diags := request.State.Get(ctx, &state)
+
+	response.Diagnostics.Append(diags...)
+	if response.Diagnostics.HasError() {
+		return
+	}
+
+	var desired managedKubernetesEngineState
+	diags = request.Plan.Get(ctx, &desired)
+
+	response.Diagnostics.Append(diags...)
+	if response.Diagnostics.HasError() {
+		return
+	}
+
+	platform, err := r.tenancyClient.GetVpcPlatform(ctx, state.VpcId.ValueString())
+	if err != nil {
+		response.Diagnostics.Append(diag2.NewErrorDiagnostic("Error getting platform", err.Error()))
+		return
+	}
+
+	isWakeup := desired.IsRunning.ValueBool()
+
+	path := commons.ApiPath.ManagedFKEHibernate(state.VpcId.ValueString(), strings.ToLower(platform), state.Id.ValueString(), isWakeup)
+	a, err := r.mfkeClient.sendPatch(path, platform, nil)
+	if err != nil {
+		d := diag2.NewErrorDiagnostic("Error calling hibernate API", err.Error())
+		response.Diagnostics.Append(d)
+		return
+	}
+
+	if diagErr2 := fptcloud_dfke.CheckForError(a); diagErr2 != nil {
+		response.Diagnostics.Append(diagErr2)
+		return
+	}
+
+	err = r.internalRead(ctx, state.Id.ValueString(), &state)
+	if err != nil {
+		response.Diagnostics.Append(diag2.NewErrorDiagnostic("Error refreshing state", err.Error()))
+		return
+	}
+
+	diags = response.State.Set(ctx, &state)
+	response.Diagnostics.Append(diags...)
+	if response.Diagnostics.HasError() {
+		return
+	}
+}
+
+func (r *resourceManagedKubernetesEngineState) Delete(ctx context.Context, request resource.DeleteRequest, response *resource.DeleteResponse) {
+	response.Diagnostics.AddError("Unsupported operation", "Deleting state of a cluster isn't supported")
+}
+
+func (r *resourceManagedKubernetesEngineState) Configure(ctx context.Context, request resource.ConfigureRequest, response *resource.ConfigureResponse) {
+	if request.ProviderData == nil {
+		return
+	}
+
+	client, ok := request.ProviderData.(*commons.Client)
+	if !ok {
+		response.Diagnostics.AddError(
+			"Unexpected Resource Configure Type",
+			fmt.Sprintf("Expected *commons.Client, got: %T. Please report this issue to the provider developers.", request.ProviderData),
+		)
+
+		return
+	}
+
+	//r.client = client
+	r.mfkeClient = newMfkeApiClient(client)
+	r.tenancyClient = fptcloud_dfke.NewTenancyApiClient(client)
+}
+
+func (r *resourceManagedKubernetesEngineState) internalRead(ctx context.Context, clusterId string, state *managedKubernetesEngineState) error {
+	vpcId := state.VpcId.ValueString()
+	tflog.Info(ctx, "Reading state of cluster ID "+clusterId+", VPC ID "+vpcId)
+
+	platform, err := r.tenancyClient.GetVpcPlatform(ctx, state.VpcId.ValueString())
+	if err != nil {
+		return fmt.Errorf("error getting VPC platform: %v", err)
+	}
+
+	a, err := r.mfkeClient.sendGet(commons.ApiPath.ManagedFKEGet(vpcId, strings.ToLower(platform), clusterId), platform)
+
+	if err != nil {
+		return err
+	}
+
+	var d managedKubernetesEngineReadResponse
+	err = json.Unmarshal(a, &d)
+	if err != nil {
+		return err
+	}
+
+	status := strings.ToUpper(d.Data.Status.LastOperation.State)
+	isRunning := false
+	if len(d.Data.Status.Conditions) > 0 {
+		isRunning = d.Data.Status.Conditions[0].Status == "True"
+	}
+	if d.Data.Spec.Hibernate != nil {
+		isRunning = !d.Data.Spec.Hibernate.Enabled
+	}
+
+	tflog.Info(ctx, fmt.Sprintf("spec.hibernate: %v", d.Data.Spec.Hibernate))
+
+	if status != "SUCCEEDED" && status != "PROCESSING" {
+		return errors.New("cluster is running, but status is " + status + " instead of SUCCEEDED")
+	}
+
+	state.IsRunning = types.BoolValue(isRunning)
+	return nil
+}
+
+type managedKubernetesEngineState struct {
+	Id        types.String `tfsdk:"id"`
+	VpcId     types.String `tfsdk:"vpc_id"`
+	IsRunning types.Bool   `tfsdk:"is_running"`
+}

--- a/fptcloud/mfke/util_network.go
+++ b/fptcloud/mfke/util_network.go
@@ -36,5 +36,5 @@ func getNetworkId(ctx context.Context, client fptcloud_subnet.SubnetService, vpc
 		return "", err
 	}
 
-	return networks.ID, nil
+	return networks.NetworkID, nil
 }

--- a/fptcloud/mfke/util_validations.go
+++ b/fptcloud/mfke/util_validations.go
@@ -3,6 +3,7 @@ package fptcloud_mfke
 import (
 	"fmt"
 	diag2 "github.com/hashicorp/terraform-plugin-framework/diag"
+	"slices"
 	"strings"
 )
 
@@ -60,6 +61,15 @@ func validateNetwork(state *managedKubernetesEngine, platform string) *diag2.Err
 
 			return &d
 		}
+	}
+
+	networkOverlayAllowed := []string{"Always", "CrossSubnet"}
+	if !slices.Contains(networkOverlayAllowed, state.NetworkOverlay.ValueString()) {
+		d := diag2.NewErrorDiagnostic(
+			"Invalid Network Overlay configuration",
+			fmt.Sprintf("Network overlay allowed values are: %s", strings.Join(networkOverlayAllowed, ", ")),
+		)
+		return &d
 	}
 
 	return nil

--- a/fptcloud/provider_tf6.go
+++ b/fptcloud/provider_tf6.go
@@ -172,6 +172,7 @@ func (x *xplatProvider) Resources(ctx context.Context) []func() resource.Resourc
 		fptcloud_dfke.NewResourceDedicatedKubernetesEngine,
 		fptcloud_dfke.NewResourceDedicatedKubernetesEngineState,
 		fptcloud_mfke.NewResourceManagedKubernetesEngine,
+		fptcloud_mfke.NewResourceDedicatedKubernetesEngineState,
 		fptcloud_database.NewResourceDatabase,
 		fptcloud_database.NewResourceDatabaseStatus,
 	}


### PR DESCRIPTION
Example for M-FKE:
```terraform
resource "fptcloud_managed_kubernetes_engine_v1" "test" {
  vpc_id = "c072ace4-d0e9-494f-a003-6e6359be0987"

  cluster_name = "test-terraform"
  # network_id = "urn:vcloud:network:169a258e-ffcd-4f7a-9177-cce1685cb17b"
  network_id = ""
  network_overlay = "CrossSubnet" or `Always`
  k8s_version = "1.29.1"
  purpose = "general" # or `firewall`
  edge_gateway_id = "urn:vcloud:gateway:bbfd00e5-7572-48cf-af4b-2ceee2b9d050"
  pools {
    name = "test"
    storage_profile = "Premium-SSD-4000"
    worker_type = "3da07e25-a5f5-40a3-a5a9-2e64ab708cff" # flavor id
    worker_disk_size = 40
    auto_scale = false
    scale_min = 1
    scale_max = 1
    network_id = "urn:vcloud:network:169a258e-ffcd-4f7a-9177-cce1685cb17b"
    network_name = "example-subnet-name"
    is_enable_auto_repair = true
  }

  pod_network = "100.96.0.0"
  pod_prefix = "11"
  service_network = "100.64.0.0"
  service_prefix = "13"
  network_node_prefix = 23
  k8s_max_pod = 110
  range_ip_lb_start = "169.254.64.1"
  range_ip_lb_end = "169.254.127.254"
  load_balancer_type = "balanced"
}
```

Example for Hibernating:
```terraform
resource "fptcloud_managed_kubernetes_engine_v1_state" "test_state" {
  id = resource.fptcloud_managed_kubernetes_engine_v1.test.id
  vpc_id = resource.fptcloud_managed_kubernetes_engine_v1.test.vpc_id
  is_running = true # false will hibernate this cluster, true will perform wakeup 
}
```