### PR TITLE
fix(commons): keep the API's error message for every HTTP status

### DIFF
--- a/commons/errors.go
+++ b/commons/errors.go
@@ -57,6 +57,21 @@ func (err wrapError) Is(target error) bool {
 	return constError(err.msg).Is(target)
 }
 
+// reasonError renders as the reason the API sent, so a wrapped error reads
+// "HttpError: <reason>" and not the full "<code>: <status>, <reason>" dump,
+// while still carrying the HTTPError for errors.As.
+type reasonError struct {
+	http HTTPError
+}
+
+func (err reasonError) Error() string {
+	return err.http.Reason
+}
+
+func (err reasonError) Unwrap() error {
+	return err.http
+}
+
 func DecodeError(err error) error {
 	var urlErr *url.Error
 	var netErr net.Error
@@ -69,9 +84,16 @@ func DecodeError(err error) error {
 	}
 
 	if errors.As(err, &httpErr) {
-		if httpErr.Code == 400 {
-			return HttpError.WrapString(httpErr.Reason)
-		}
+		// Every status keeps the reason the API sent. Only 400 used to: 404,
+		// 409, 422 and 5xx all collapsed into "System error, please try again !",
+		// so a message the API had already written for the user (e.g. "Security
+		// group name already exists") never reached them.
+		//
+		// Wrapping the HTTPError itself -- rather than only its text -- also
+		// keeps the status code reachable via errors.As. Callers already try
+		// that (see fptcloud/storage/resource_storage.go), but it could never
+		// match while the original error was dropped here.
+		return HttpError.Wrap(reasonError{http: httpErr})
 	}
 	return UnknownError.WrapString("System error, please try again !")
 }

--- a/commons/errors_test.go
+++ b/commons/errors_test.go
@@ -43,3 +43,34 @@ func TestDecodeError_ReturnsUnknownError(t *testing.T) {
 	assert.True(t, errors.Is(err, UnknownError))
 	assert.Equal(t, "UnknownError: System error, please try again !", err.Error())
 }
+
+// A 404/409/422/5xx used to become "System error, please try again !", hiding
+// the message the API sent. Terraform users saw that for a duplicate security
+// group name, a missing storage volume, and every operation failure.
+func TestDecodeError_KeepsReasonForEveryStatus(t *testing.T) {
+	for _, code := range []int{400, 401, 403, 404, 409, 422, 500, 503} {
+		httpErr := HTTPError{
+			Code:   code,
+			Status: "irrelevant",
+			Reason: "Security group name already exists",
+		}
+
+		err := DecodeError(httpErr)
+
+		assert.True(t, errors.Is(err, HttpError), "status %d", code)
+		assert.Equal(t,
+			"HttpError: Security group name already exists", err.Error(),
+			"status %d", code)
+	}
+}
+
+// Callers branch on the status code (resource_storage.go treats 404 as "gone").
+// That could never work while DecodeError dropped the original error.
+func TestDecodeError_KeepsStatusCodeReachable(t *testing.T) {
+	err := DecodeError(HTTPError{Code: 404, Reason: "Storage not found"})
+
+	var httpErr HTTPError
+	assert.True(t, errors.As(err, &httpErr))
+	assert.Equal(t, 404, httpErr.Code)
+	assert.Equal(t, "Storage not found", httpErr.Reason)
+}


### PR DESCRIPTION
## Problem

`commons/errors.go` → `DecodeError` only preserves the API's message on HTTP **400**:

```go
if errors.As(err, &httpErr) {
    if httpErr.Code == 400 {
        return HttpError.WrapString(httpErr.Reason)
    }
}
return UnknownError.WrapString("System error, please try again !")
```

Every other status — `401`, `403`, `404`, `409`, `422`, `5xx` — is replaced by the literal string **`System error, please try again !`**. The message the API had already written for the user never reaches them.

`DecodeError` is used at **80 call sites**, so this affects every resource and data source.

Real cases users hit today:

| Action | API returns | User sees today |
|---|---|---|
| Create security group with a duplicate name | `409` + *"Security group name already exists"* | `System error, please try again !` |
| Delete a storage volume that no longer exists | `404` + *"Storage not found"* | `System error, please try again !` |
| Any operation-failure (create/delete/rename SG, rule, tags) | `5xx` + curated message | `System error, please try again !` |

### Second effect: the status code is unreachable

`DecodeError` returns `wrapError{msg, errors.New(...)}` — the original `HTTPError` is **not** in the chain. So this block in `fptcloud/storage/resource_storage.go` can never run:

```go
var httpErr common.HTTPError
if errors.As(err, &httpErr) {
    if httpErr.Code == 404 {
        log.Printf("[WARN] Storage %s not found (404), keeping in state for retry", d.Id())
        ...
```

It silently falls through to the generic branch below it, which matches on the message text (`strings.Contains(errStr, "not found")`) instead.

## Fix

Wrap the `HTTPError` itself rather than only its text.

`reasonError` renders as the reason, so the message keeps its current shape — `"HttpError: <reason>"`, which the existing `TestDecodeError_HandlesHttpError` still asserts byte for byte — while `Unwrap` exposes the `HTTPError` to `errors.As`.

Non-HTTP errors are unchanged and still map to `UnknownError`; the timeout branch is untouched.

## Compatibility

- **400 behaviour is byte-identical** — existing test unchanged and passing.
- No caller outside `commons/errors*.go` references `UnknownError` or the `HttpError` sentinel (checked by grep), so widening the preserved-message path breaks nothing.
- `resource_storage.go`'s `httpErr.Code == 404` branch starts working as originally intended. It logs and returns an error, keeping the resource in state — same outcome as the string-matching fallback it used to reach, with a clearer diagnostic.

## Tests

Two added, both fail against the previous `DecodeError` (verified by reverting it), so they lock the behaviour rather than restate it:

- `TestDecodeError_KeepsReasonForEveryStatus` — 400/401/403/404/409/422/500/503 all keep the reason.
- `TestDecodeError_KeepsStatusCodeReachable` — `errors.As` recovers the `HTTPError` and its `Code`.

```
go build ./...   ok
go vet ./commons/...   ok
go test ./...    17 packages ok, 0 failures
gofmt -l         clean
```

## Context

Found while auditing a backend change that assigns semantic HTTP statuses (404/409/422) to errors that previously all returned 400. On the API side those statuses are correct; with `DecodeError` as it stands they would make every affected Terraform error message disappear. The backend is shipping a temporary workaround that pins those endpoints back to 400 — this PR is what lets that workaround be removed.
