### PR TITLE
Feat: support `Status` in bucket lifecycle rule so a rule can be created Disabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,15 @@
+## [0.3.61] - 2026-08-19
+
+### Resource
+
+- Feat: support `Status` in bucket lifecycle rule so a rule can be created Disabled
+- Fix: send only the fields a lifecycle rule declares, instead of omitted objects as zero values the API rejects
+- Fix: do not record a bucket lifecycle rule in state when its create fails
+- Fix: detect lifecycle and CORS rules deleted outside Terraform instead of reporting them as present
+- Fix: treat a missing bucket as drift instead of failing the plan
+- Fix: report a failed bucket static website create as an error instead of success
+- Fix: adopt object storage objects left behind by a create whose response was lost
+
 ## [0.3.60] - 2026-08-13
 
 ### Datasource

--- a/fptcloud/object-storage/model_object_storage.go
+++ b/fptcloud/object-storage/model_object_storage.go
@@ -196,12 +196,19 @@ type PutBucketAclResponse struct {
 	TaskID string `json:"taskId"`
 }
 
+// S3BucketLifecycleConfig mirrors one rule of a bucket lifecycle configuration.
+//
+// The nested objects are pointers so that "absent" and "present but zero" stay
+// distinguishable: a value type cannot express the difference, and sending an
+// omitted object as {"NoncurrentDays": 0} makes the API reject the rule with
+// InvalidArgument. Only the fields the user actually wrote are marshalled.
 type S3BucketLifecycleConfig struct {
-	ID                             string                         `json:"ID"`
-	Filter                         Filter                         `json:"Filter"`
-	Expiration                     Expiration                     `json:"Expiration"`
-	NoncurrentVersionExpiration    NoncurrentVersionExpiration    `json:"NoncurrentVersionExpiration"`
-	AbortIncompleteMultipartUpload AbortIncompleteMultipartUpload `json:"AbortIncompleteMultipartUpload"`
+	ID                             string                          `json:"ID"`
+	Status                         string                          `json:"Status,omitempty"`
+	Filter                         *Filter                         `json:"Filter,omitempty"`
+	Expiration                     *Expiration                     `json:"Expiration,omitempty"`
+	NoncurrentVersionExpiration    *NoncurrentVersionExpiration    `json:"NoncurrentVersionExpiration,omitempty"`
+	AbortIncompleteMultipartUpload *AbortIncompleteMultipartUpload `json:"AbortIncompleteMultipartUpload,omitempty"`
 }
 
 type S3ServiceEnableResponse struct {

--- a/fptcloud/object-storage/model_test.go
+++ b/fptcloud/object-storage/model_test.go
@@ -174,34 +174,51 @@ func TestS3BucketLifecycleConfigSerialization(t *testing.T) {
 		{
 			name: "lifecycle config with expiration",
 			config: fptcloud_object_storage.S3BucketLifecycleConfig{
-				ID: "rule1",
-				Filter: fptcloud_object_storage.Filter{
+				ID:     "rule1",
+				Status: "Enabled",
+				Filter: &fptcloud_object_storage.Filter{
 					Prefix: "logs/",
 				},
-				Expiration: fptcloud_object_storage.Expiration{
+				Expiration: &fptcloud_object_storage.Expiration{
 					Days: 30,
 				},
-				NoncurrentVersionExpiration: fptcloud_object_storage.NoncurrentVersionExpiration{
+				NoncurrentVersionExpiration: &fptcloud_object_storage.NoncurrentVersionExpiration{
 					NoncurrentDays: 90,
 				},
-				AbortIncompleteMultipartUpload: fptcloud_object_storage.AbortIncompleteMultipartUpload{
+				AbortIncompleteMultipartUpload: &fptcloud_object_storage.AbortIncompleteMultipartUpload{
 					DaysAfterInitiation: 7,
 				},
 			},
-			expected: `{"ID":"rule1","Filter":{"Prefix":"logs/"},"Expiration":{"Days":30},"NoncurrentVersionExpiration":{"NoncurrentDays":90},"AbortIncompleteMultipartUpload":{"DaysAfterInitiation":7}}`,
+			expected: `{"ID":"rule1","Status":"Enabled","Filter":{"Prefix":"logs/"},"Expiration":{"Days":30},"NoncurrentVersionExpiration":{"NoncurrentDays":90},"AbortIncompleteMultipartUpload":{"DaysAfterInitiation":7}}`,
 		},
 		{
-			name: "lifecycle config with delete marker expiration",
+			// Objects the rule does not declare must stay out of the JSON entirely,
+			// rather than appearing as zero values the API rejects.
+			name: "lifecycle config omits undeclared objects",
 			config: fptcloud_object_storage.S3BucketLifecycleConfig{
 				ID: "rule2",
-				Filter: fptcloud_object_storage.Filter{
+				Filter: &fptcloud_object_storage.Filter{
 					Prefix: "temp/",
 				},
-				Expiration: fptcloud_object_storage.Expiration{
+				Expiration: &fptcloud_object_storage.Expiration{
 					ExpiredObjectDeleteMarker: true,
 				},
 			},
-			expected: `{"ID":"rule2","Filter":{"Prefix":"temp/"},"Expiration":{"ExpiredObjectDeleteMarker":true},"NoncurrentVersionExpiration":{"NoncurrentDays":0},"AbortIncompleteMultipartUpload":{"DaysAfterInitiation":0}}`,
+			expected: `{"ID":"rule2","Filter":{"Prefix":"temp/"},"Expiration":{"ExpiredObjectDeleteMarker":true}}`,
+		},
+		{
+			name: "lifecycle config with disabled status",
+			config: fptcloud_object_storage.S3BucketLifecycleConfig{
+				ID:     "rule3",
+				Status: "Disabled",
+				Filter: &fptcloud_object_storage.Filter{
+					Prefix: "tmp/",
+				},
+				Expiration: &fptcloud_object_storage.Expiration{
+					Days: 30,
+				},
+			},
+			expected: `{"ID":"rule3","Status":"Disabled","Filter":{"Prefix":"tmp/"},"Expiration":{"Days":30}}`,
 		},
 	}
 
@@ -222,40 +239,48 @@ func TestS3BucketLifecycleConfigDeserialization(t *testing.T) {
 	}{
 		{
 			name:     "lifecycle config with expiration",
-			jsonData: `{"ID":"rule1","Filter":{"Prefix":"logs/"},"Expiration":{"Days":30},"NoncurrentVersionExpiration":{"NoncurrentDays":90},"AbortIncompleteMultipartUpload":{"DaysAfterInitiation":7}}`,
+			jsonData: `{"ID":"rule1","Status":"Enabled","Filter":{"Prefix":"logs/"},"Expiration":{"Days":30},"NoncurrentVersionExpiration":{"NoncurrentDays":90},"AbortIncompleteMultipartUpload":{"DaysAfterInitiation":7}}`,
 			expected: fptcloud_object_storage.S3BucketLifecycleConfig{
-				ID: "rule1",
-				Filter: fptcloud_object_storage.Filter{
+				ID:     "rule1",
+				Status: "Enabled",
+				Filter: &fptcloud_object_storage.Filter{
 					Prefix: "logs/",
 				},
-				Expiration: fptcloud_object_storage.Expiration{
+				Expiration: &fptcloud_object_storage.Expiration{
 					Days: 30,
 				},
-				NoncurrentVersionExpiration: fptcloud_object_storage.NoncurrentVersionExpiration{
+				NoncurrentVersionExpiration: &fptcloud_object_storage.NoncurrentVersionExpiration{
 					NoncurrentDays: 90,
 				},
-				AbortIncompleteMultipartUpload: fptcloud_object_storage.AbortIncompleteMultipartUpload{
+				AbortIncompleteMultipartUpload: &fptcloud_object_storage.AbortIncompleteMultipartUpload{
 					DaysAfterInitiation: 7,
 				},
 			},
 		},
 		{
-			name:     "lifecycle config with delete marker expiration",
-			jsonData: `{"ID":"rule2","Filter":{"Prefix":"temp/"},"Expiration":{"ExpiredObjectDeleteMarker":true},"NoncurrentVersionExpiration":{"NoncurrentDays":0},"AbortIncompleteMultipartUpload":{"DaysAfterInitiation":0}}`,
+			// Keys the JSON never mentions must stay nil, so the caller can tell them
+			// apart from a value that really was written as zero.
+			name:     "undeclared objects stay nil",
+			jsonData: `{"ID":"rule2","Filter":{"Prefix":"temp/"},"Expiration":{"ExpiredObjectDeleteMarker":true}}`,
 			expected: fptcloud_object_storage.S3BucketLifecycleConfig{
 				ID: "rule2",
-				Filter: fptcloud_object_storage.Filter{
+				Filter: &fptcloud_object_storage.Filter{
 					Prefix: "temp/",
 				},
-				Expiration: fptcloud_object_storage.Expiration{
+				Expiration: &fptcloud_object_storage.Expiration{
 					ExpiredObjectDeleteMarker: true,
 				},
-				NoncurrentVersionExpiration: fptcloud_object_storage.NoncurrentVersionExpiration{
-					NoncurrentDays: 0,
-				},
-				AbortIncompleteMultipartUpload: fptcloud_object_storage.AbortIncompleteMultipartUpload{
-					DaysAfterInitiation: 0,
-				},
+				NoncurrentVersionExpiration:    nil,
+				AbortIncompleteMultipartUpload: nil,
+			},
+		},
+		{
+			// An explicit zero is distinguishable from an omission: present, not nil.
+			name:     "explicit zero is preserved",
+			jsonData: `{"ID":"rule3","NoncurrentVersionExpiration":{"NoncurrentDays":0}}`,
+			expected: fptcloud_object_storage.S3BucketLifecycleConfig{
+				ID:                          "rule3",
+				NoncurrentVersionExpiration: &fptcloud_object_storage.NoncurrentVersionExpiration{NoncurrentDays: 0},
 			},
 		},
 	}

--- a/fptcloud/object-storage/reconcile.go
+++ b/fptcloud/object-storage/reconcile.go
@@ -1,0 +1,206 @@
+package fptcloud_object_storage
+
+import (
+	"encoding/json"
+	"reflect"
+)
+
+// Creates in this API are not idempotent. The backend commits before the
+// response reaches the client, so a response lost in transit - a gateway 504 is
+// the common case - leaves an object behind that Terraform never recorded. The
+// next apply retries the same POST, the backend answers "already exists", and no
+// amount of retrying resolves it: there is no state entry to destroy, and these
+// resources have no importer.
+//
+// Every create therefore reconciles when the call reports failure: it asks the
+// API what is actually there and adopts the object only when it matches the
+// configuration. An object of the same name carrying different settings is a
+// real conflict and is reported as one, so a timed-out create is recovered
+// without silently taking ownership of somebody else's object.
+//
+// Access keys are deliberately excluded. Their secret is returned only by the
+// create call and cannot be read back, so an adopted key would be recorded
+// without a usable secret - worse than a clean failure.
+
+// createOutcome is the verdict of a read-back performed after a create reported
+// failure.
+type createOutcome int
+
+const (
+	// createFailed - nothing matching is on the server, so the original error
+	// stands and is reported unchanged.
+	createFailed createOutcome = iota
+	// createAdopted - the object described by the configuration is present, so
+	// the create had in fact succeeded and the resource is recorded as normal.
+	createAdopted
+	// createConflict - an object of that name exists but does not match the
+	// configuration, so it is not ours to take over.
+	createConflict
+)
+
+// reconcileBucket adopts a bucket only when it is empty. A bucket that already
+// holds objects is somebody else's: adopting it would place data under Terraform
+// management that a later destroy would delete. ListBuckets does not report acl
+// or versioning, so emptiness is the only signal available here.
+func reconcileBucket(service ObjectStorageService, vpcId, s3ServiceId, name string) createOutcome {
+	buckets := service.ListBuckets(vpcId, s3ServiceId, 1, 1000)
+	for _, bucket := range buckets.Buckets {
+		if bucket.Name != name {
+			continue
+		}
+		if bucket.IsEmpty {
+			return createAdopted
+		}
+		return createConflict
+	}
+	return createFailed
+}
+
+// reconcileLifeCycleRule compares every field the rule declares against the
+// stored rule. Fields the configuration omits are not compared, because the
+// backend fills its own defaults for them.
+func reconcileLifeCycleRule(service ObjectStorageService, vpcId, s3ServiceId, bucketName string, want S3BucketLifecycleConfig) createOutcome {
+	response := service.GetBucketLifecycle(vpcId, s3ServiceId, bucketName, 1, maxRulesPerPage)
+	if !response.Status {
+		return createFailed
+	}
+	for _, rule := range response.Rules {
+		if rule.ID != want.ID {
+			continue
+		}
+		if want.Status != "" && rule.Status != want.Status {
+			return createConflict
+		}
+		if want.Filter != nil && rule.Filter.Prefix != want.Filter.Prefix {
+			return createConflict
+		}
+		if want.Expiration != nil &&
+			(rule.Expiration.Days != want.Expiration.Days ||
+				rule.Expiration.ExpiredObjectDeleteMarker != want.Expiration.ExpiredObjectDeleteMarker) {
+			return createConflict
+		}
+		if want.NoncurrentVersionExpiration != nil &&
+			rule.NoncurrentVersionExpiration.NoncurrentDays != want.NoncurrentVersionExpiration.NoncurrentDays {
+			return createConflict
+		}
+		if want.AbortIncompleteMultipartUpload != nil &&
+			rule.AbortIncompleteMultipartUpload.DaysAfterInitiation != want.AbortIncompleteMultipartUpload.DaysAfterInitiation {
+			return createConflict
+		}
+		return createAdopted
+	}
+	return createFailed
+}
+
+// reconcileCorsRule compares the stored rule against the one the configuration
+// asks for. Header lists are optional, so they are compared only when declared.
+func reconcileCorsRule(service ObjectStorageService, vpcId, s3ServiceId, bucketName string, want CorsRule) createOutcome {
+	response, err := service.GetBucketCors(vpcId, s3ServiceId, bucketName, 1, maxRulesPerPage)
+	if err != nil || response == nil || !response.Status {
+		return createFailed
+	}
+	for _, rule := range response.CorsRules {
+		if rule.ID != want.ID {
+			continue
+		}
+		if !equalStrings(rule.AllowedMethods, want.AllowedMethods) ||
+			!equalStrings(rule.AllowedOrigins, want.AllowedOrigins) ||
+			rule.MaxAgeSeconds != want.MaxAgeSeconds {
+			return createConflict
+		}
+		if len(want.AllowedHeaders) > 0 && !equalStrings(rule.AllowedHeaders, want.AllowedHeaders) {
+			return createConflict
+		}
+		if len(want.ExposeHeaders) > 0 && !equalStrings(rule.ExposeHeaders, want.ExposeHeaders) {
+			return createConflict
+		}
+		return createAdopted
+	}
+	return createFailed
+}
+
+// reconcileBucketPolicy compares the stored document with the configured one
+// semantically, so formatting differences do not read as a conflict.
+func reconcileBucketPolicy(service ObjectStorageService, vpcId, s3ServiceId, bucketName, want string) createOutcome {
+	response := service.GetBucketPolicy(vpcId, s3ServiceId, bucketName)
+	if response == nil || !response.Status || response.Policy == "" {
+		return createFailed
+	}
+	if equalJSON(response.Policy, want) {
+		return createAdopted
+	}
+	return createConflict
+}
+
+// reconcileBucketAcl treats the desired canned ACL already being in place as
+// success: PutBucketAcl overwrites, so there is nothing else to own.
+func reconcileBucketAcl(service ObjectStorageService, vpcId, s3ServiceId, bucketName, want string) createOutcome {
+	response := service.GetBucketAcl(vpcId, s3ServiceId, bucketName)
+	if response == nil || !response.Status {
+		return createFailed
+	}
+	if response.CannedACL == want {
+		return createAdopted
+	}
+	return createFailed
+}
+
+// reconcileBucketVersioning mirrors reconcileBucketAcl: the setting is a single
+// overwritable value, so finding it already applied means the call landed.
+func reconcileBucketVersioning(service ObjectStorageService, vpcId, s3ServiceId, bucketName, want string) createOutcome {
+	response := service.GetBucketVersioning(vpcId, s3ServiceId, bucketName)
+	if response == nil || !response.Status {
+		return createFailed
+	}
+	if response.Config == want {
+		return createAdopted
+	}
+	return createFailed
+}
+
+// reconcileBucketWebsite reports whether a website configuration is present.
+// GetBucketWebsite does not return the index and error documents in a form that
+// can be compared, so presence is the only available signal.
+func reconcileBucketWebsite(service ObjectStorageService, vpcId, s3ServiceId, bucketName string) createOutcome {
+	response := service.GetBucketWebsite(vpcId, s3ServiceId, bucketName)
+	if response == nil || !response.Status {
+		return createFailed
+	}
+	return createAdopted
+}
+
+// reconcileSubUser adopts a sub-user only when the stored role matches, so a
+// pre-existing user with different permissions is reported as a conflict.
+func reconcileSubUser(service ObjectStorageService, vpcId, s3ServiceId, subUserId, wantRole string) createOutcome {
+	detail := service.DetailSubUser(vpcId, s3ServiceId, subUserId)
+	if detail == nil || detail.UserID != subUserId {
+		return createFailed
+	}
+	if detail.Role != wantRole {
+		return createConflict
+	}
+	return createAdopted
+}
+
+// maxRulesPerPage matches the page size the read functions already use when
+// listing a bucket's rules.
+const maxRulesPerPage = 999999
+
+func equalStrings(a, b []string) bool {
+	if len(a) == 0 && len(b) == 0 {
+		return true
+	}
+	return reflect.DeepEqual(a, b)
+}
+
+// equalJSON compares two documents by structure rather than by text.
+func equalJSON(a, b string) bool {
+	var left, right interface{}
+	if err := json.Unmarshal([]byte(a), &left); err != nil {
+		return false
+	}
+	if err := json.Unmarshal([]byte(b), &right); err != nil {
+		return false
+	}
+	return reflect.DeepEqual(left, right)
+}

--- a/fptcloud/object-storage/reconcile_test.go
+++ b/fptcloud/object-storage/reconcile_test.go
@@ -1,0 +1,294 @@
+package fptcloud_object_storage
+
+import (
+	"encoding/json"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// fakeService serves canned read-back responses. The embedded interface is nil,
+// so a reconcile helper that reaches for anything beyond the read it is supposed
+// to use panics rather than passing quietly.
+type fakeService struct {
+	ObjectStorageService
+
+	lifecycle  BucketLifecycleResponse
+	cors       *BucketCorsResponse
+	corsErr    error
+	buckets    ListBucketResponse
+	policy     *BucketPolicyResponse
+	acl        *BucketAclResponse
+	versioning *BucketVersioningResponse
+	website    *BucketWebsiteResponse
+	subUser    *DetailSubUser
+}
+
+func (f fakeService) GetBucketLifecycle(_, _, _ string, _, _ int) BucketLifecycleResponse {
+	return f.lifecycle
+}
+func (f fakeService) GetBucketCors(_, _, _ string, _, _ int) (*BucketCorsResponse, error) {
+	return f.cors, f.corsErr
+}
+func (f fakeService) ListBuckets(_, _ string, _, _ int) ListBucketResponse { return f.buckets }
+func (f fakeService) GetBucketPolicy(_, _, _ string) *BucketPolicyResponse { return f.policy }
+func (f fakeService) GetBucketAcl(_, _, _ string) *BucketAclResponse       { return f.acl }
+func (f fakeService) GetBucketVersioning(_, _, _ string) *BucketVersioningResponse {
+	return f.versioning
+}
+func (f fakeService) GetBucketWebsite(_, _, _ string) *BucketWebsiteResponse { return f.website }
+func (f fakeService) DetailSubUser(_, _, _ string) *DetailSubUser            { return f.subUser }
+
+// The response models nest anonymous structs, so canned data is built from JSON
+// rather than from struct literals.
+func decode[T any](t *testing.T, raw string) T {
+	t.Helper()
+	var out T
+	if err := json.Unmarshal([]byte(raw), &out); err != nil {
+		t.Fatalf("bad test fixture: %v", err)
+	}
+	return out
+}
+
+func rule(id string) S3BucketLifecycleConfig {
+	return S3BucketLifecycleConfig{ID: id}
+}
+
+func TestReconcileLifeCycleRule(t *testing.T) {
+	const stored = `{"status":true,"total":1,"rules":[{
+		"ID":"expire-tmp","Status":"Disabled",
+		"Filter":{"Prefix":"tmp/"},"Expiration":{"Days":30},
+		"NoncurrentVersionExpiration":{"NoncurrentDays":0},
+		"AbortIncompleteMultipartUpload":{"DaysAfterInitiation":0}}]}`
+
+	want := func(mutate func(*S3BucketLifecycleConfig)) S3BucketLifecycleConfig {
+		c := rule("expire-tmp")
+		c.Status = "Disabled"
+		c.Filter = &Filter{Prefix: "tmp/"}
+		c.Expiration = &Expiration{Days: 30}
+		if mutate != nil {
+			mutate(&c)
+		}
+		return c
+	}
+
+	tests := []struct {
+		name     string
+		response string
+		want     S3BucketLifecycleConfig
+		expected createOutcome
+	}{
+		{
+			// The 504 case: the rule committed, only the response was lost.
+			name: "adopts the rule it asked for", response: stored,
+			want: want(nil), expected: createAdopted,
+		},
+		{
+			// Fields the config omits are the backend's business, not a conflict.
+			name: "adopts when config omits fields the backend defaulted", response: stored,
+			want: rule("expire-tmp"), expected: createAdopted,
+		},
+		{
+			name: "conflict when status differs", response: stored,
+			want: want(func(c *S3BucketLifecycleConfig) { c.Status = "Enabled" }), expected: createConflict,
+		},
+		{
+			name: "conflict when expiration differs", response: stored,
+			want: want(func(c *S3BucketLifecycleConfig) { c.Expiration = &Expiration{Days: 60} }), expected: createConflict,
+		},
+		{
+			name: "conflict when prefix differs", response: stored,
+			want: want(func(c *S3BucketLifecycleConfig) { c.Filter = &Filter{Prefix: "other/"} }), expected: createConflict,
+		},
+		{
+			name: "conflict when a declared zero differs from stored", response: stored,
+			want: want(func(c *S3BucketLifecycleConfig) {
+				c.NoncurrentVersionExpiration = &NoncurrentVersionExpiration{NoncurrentDays: 30}
+			}), expected: createConflict,
+		},
+		{
+			name: "adopts when a declared zero matches stored", response: stored,
+			want: want(func(c *S3BucketLifecycleConfig) {
+				c.NoncurrentVersionExpiration = &NoncurrentVersionExpiration{NoncurrentDays: 0}
+			}), expected: createAdopted,
+		},
+		{
+			name: "failed when the rule is absent", response: `{"status":true,"total":0,"rules":[]}`,
+			want: want(nil), expected: createFailed,
+		},
+		{
+			name: "failed when another rule holds the bucket", response: stored,
+			want: rule("something-else"), expected: createFailed,
+		},
+		{
+			name: "failed when the read itself fails", response: `{"status":false}`,
+			want: want(nil), expected: createFailed,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			svc := fakeService{lifecycle: decode[BucketLifecycleResponse](t, tt.response)}
+			assert.Equal(t, tt.expected, reconcileLifeCycleRule(svc, "vpc", "s3", "bucket", tt.want))
+		})
+	}
+}
+
+func TestReconcileCorsRule(t *testing.T) {
+	const stored = `{"status":true,"total":1,"cors_rules":[{
+		"ID":"app-cors","AllowedMethods":["GET","PUT"],
+		"AllowedOrigins":["https://app.example.com"],"MaxAgeSeconds":3600}]}`
+
+	base := CorsRule{
+		ID:             "app-cors",
+		AllowedMethods: []string{"GET", "PUT"},
+		AllowedOrigins: []string{"https://app.example.com"},
+		MaxAgeSeconds:  3600,
+	}
+
+	t.Run("adopts the rule it asked for", func(t *testing.T) {
+		svc := fakeService{cors: ptr(decode[BucketCorsResponse](t, stored))}
+		assert.Equal(t, createAdopted, reconcileCorsRule(svc, "vpc", "s3", "bucket", base))
+	})
+
+	t.Run("conflict when max age differs", func(t *testing.T) {
+		other := base
+		other.MaxAgeSeconds = 600
+		svc := fakeService{cors: ptr(decode[BucketCorsResponse](t, stored))}
+		assert.Equal(t, createConflict, reconcileCorsRule(svc, "vpc", "s3", "bucket", other))
+	})
+
+	t.Run("conflict when methods differ", func(t *testing.T) {
+		other := base
+		other.AllowedMethods = []string{"GET"}
+		svc := fakeService{cors: ptr(decode[BucketCorsResponse](t, stored))}
+		assert.Equal(t, createConflict, reconcileCorsRule(svc, "vpc", "s3", "bucket", other))
+	})
+
+	t.Run("adopts when undeclared optional headers are absent", func(t *testing.T) {
+		other := base
+		other.AllowedHeaders = nil
+		svc := fakeService{cors: ptr(decode[BucketCorsResponse](t, stored))}
+		assert.Equal(t, createAdopted, reconcileCorsRule(svc, "vpc", "s3", "bucket", other))
+	})
+
+	t.Run("failed when the read errors", func(t *testing.T) {
+		svc := fakeService{corsErr: errors.New("boom")}
+		assert.Equal(t, createFailed, reconcileCorsRule(svc, "vpc", "s3", "bucket", base))
+	})
+
+	t.Run("failed when the rule is absent", func(t *testing.T) {
+		svc := fakeService{cors: ptr(decode[BucketCorsResponse](t, `{"status":true,"total":0,"cors_rules":[]}`))}
+		assert.Equal(t, createFailed, reconcileCorsRule(svc, "vpc", "s3", "bucket", base))
+	})
+}
+
+func TestReconcileBucket(t *testing.T) {
+	tests := []struct {
+		name     string
+		response string
+		expected createOutcome
+	}{
+		{
+			// Empty means it is plausibly the orphan we just created.
+			name:     "adopts an empty bucket",
+			response: `{"total":1,"buckets":[{"Name":"b1","isEmpty":true}]}`,
+			expected: createAdopted,
+		},
+		{
+			// Data in it means it is somebody else's; destroy would delete it.
+			name:     "refuses a bucket that holds objects",
+			response: `{"total":1,"buckets":[{"Name":"b1","isEmpty":false}]}`,
+			expected: createConflict,
+		},
+		{
+			name:     "failed when the bucket is absent",
+			response: `{"total":1,"buckets":[{"Name":"other","isEmpty":true}]}`,
+			expected: createFailed,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			svc := fakeService{buckets: decode[ListBucketResponse](t, tt.response)}
+			assert.Equal(t, tt.expected, reconcileBucket(svc, "vpc", "s3", "b1"))
+		})
+	}
+}
+
+func TestReconcileBucketPolicy(t *testing.T) {
+	const want = `{"Version":"2012-10-17","Statement":[{"Effect":"Deny"}]}`
+
+	t.Run("adopts a policy that differs only in formatting", func(t *testing.T) {
+		svc := fakeService{policy: &BucketPolicyResponse{
+			Status: true,
+			Policy: "{\n  \"Statement\": [ { \"Effect\": \"Deny\" } ],\n  \"Version\": \"2012-10-17\"\n}",
+		}}
+		assert.Equal(t, createAdopted, reconcileBucketPolicy(svc, "vpc", "s3", "bucket", want))
+	})
+
+	t.Run("conflict when the document differs", func(t *testing.T) {
+		svc := fakeService{policy: &BucketPolicyResponse{
+			Status: true,
+			Policy: `{"Version":"2012-10-17","Statement":[{"Effect":"Allow"}]}`,
+		}}
+		assert.Equal(t, createConflict, reconcileBucketPolicy(svc, "vpc", "s3", "bucket", want))
+	})
+
+	t.Run("failed when no policy is set", func(t *testing.T) {
+		svc := fakeService{policy: &BucketPolicyResponse{Status: true, Policy: ""}}
+		assert.Equal(t, createFailed, reconcileBucketPolicy(svc, "vpc", "s3", "bucket", want))
+	})
+}
+
+func TestReconcileSubUser(t *testing.T) {
+	t.Run("adopts a user with the requested role", func(t *testing.T) {
+		svc := fakeService{subUser: &DetailSubUser{UserID: "u1", Role: "SubUserReadWrite"}}
+		assert.Equal(t, createAdopted, reconcileSubUser(svc, "vpc", "s3", "u1", "SubUserReadWrite"))
+	})
+
+	t.Run("conflict when the role differs", func(t *testing.T) {
+		svc := fakeService{subUser: &DetailSubUser{UserID: "u1", Role: "SubUserRead"}}
+		assert.Equal(t, createConflict, reconcileSubUser(svc, "vpc", "s3", "u1", "SubUserReadWrite"))
+	})
+
+	t.Run("failed when the user is absent", func(t *testing.T) {
+		svc := fakeService{subUser: nil}
+		assert.Equal(t, createFailed, reconcileSubUser(svc, "vpc", "s3", "u1", "SubUserReadWrite"))
+	})
+}
+
+func TestReconcileOverwriteSettings(t *testing.T) {
+	t.Run("acl adopts when already applied", func(t *testing.T) {
+		svc := fakeService{acl: &BucketAclResponse{Status: true, CannedACL: "private"}}
+		assert.Equal(t, createAdopted, reconcileBucketAcl(svc, "vpc", "s3", "bucket", "private"))
+		assert.Equal(t, createFailed, reconcileBucketAcl(svc, "vpc", "s3", "bucket", "public-read"))
+	})
+
+	t.Run("versioning adopts when already applied", func(t *testing.T) {
+		svc := fakeService{versioning: &BucketVersioningResponse{Status: true, Config: "Enabled"}}
+		assert.Equal(t, createAdopted, reconcileBucketVersioning(svc, "vpc", "s3", "bucket", "Enabled"))
+		assert.Equal(t, createFailed, reconcileBucketVersioning(svc, "vpc", "s3", "bucket", "Suspended"))
+	})
+
+	t.Run("website adopts when a configuration is present", func(t *testing.T) {
+		assert.Equal(t, createAdopted,
+			reconcileBucketWebsite(fakeService{website: &BucketWebsiteResponse{Status: true}}, "vpc", "s3", "bucket"))
+		assert.Equal(t, createFailed,
+			reconcileBucketWebsite(fakeService{website: nil}, "vpc", "s3", "bucket"))
+	})
+}
+
+func TestEqualHelpers(t *testing.T) {
+	assert.True(t, equalStrings(nil, nil))
+	assert.True(t, equalStrings([]string{}, nil))
+	assert.True(t, equalStrings([]string{"a", "b"}, []string{"a", "b"}))
+	assert.False(t, equalStrings([]string{"a", "b"}, []string{"b", "a"}))
+
+	assert.True(t, equalJSON(`{"a":1,"b":2}`, `{"b":2,"a":1}`))
+	assert.False(t, equalJSON(`{"a":1}`, `{"a":2}`))
+	assert.False(t, equalJSON(`not json`, `{"a":1}`))
+}
+
+func ptr[T any](v T) *T { return &v }

--- a/fptcloud/object-storage/resource_bucket.go
+++ b/fptcloud/object-storage/resource_bucket.go
@@ -111,7 +111,15 @@ func resourceBucketCreate(ctx context.Context, d *schema.ResourceData, m interfa
 
 	bucket := objectStorageService.CreateBucket(req, vpcId, s3ServiceDetail.S3ServiceId)
 	if !bucket.Status {
-		return diag.Errorf("failed to create bucket: %s", bucket.Message)
+		switch reconcileBucket(objectStorageService, vpcId, s3ServiceDetail.S3ServiceId, req.Name) {
+		case createAdopted:
+			// The bucket exists and is empty: an earlier attempt committed and only
+			// its response was lost. Record it instead of failing forever.
+		case createConflict:
+			return diag.Errorf("bucket %s already exists and is not empty, so it is not adopted; remove it or choose another name: %s", req.Name, bucket.Message)
+		default:
+			return diag.Errorf("failed to create bucket: %s", bucket.Message)
+		}
 	}
 
 	d.SetId(req.Name)
@@ -166,9 +174,12 @@ func resourceBucketRead(ctx context.Context, d *schema.ResourceData, m interface
 
 	// List buckets to find the specific bucket
 	buckets := objectStorageService.ListBuckets(vpcId, s3ServiceDetail.S3ServiceId, 1, 1000)
+	// A bucket that is no longer there is drift, not a failure: clearing the ID
+	// lets Terraform plan a recreate, whereas returning an error makes every
+	// subsequent plan fail until the state entry is removed by hand.
 	if buckets.Total == 0 {
 		d.SetId("")
-		return diag.Errorf("no buckets found")
+		return nil
 	}
 
 	// Find the specific bucket
@@ -189,7 +200,7 @@ func resourceBucketRead(ctx context.Context, d *schema.ResourceData, m interface
 
 	if foundBucket == nil {
 		d.SetId("")
-		return diag.Errorf("bucket %s not found", bucketName)
+		return nil
 	}
 
 	// Set the basic attributes

--- a/fptcloud/object-storage/resource_bucket_acl.go
+++ b/fptcloud/object-storage/resource_bucket_acl.go
@@ -76,10 +76,14 @@ func resourceBucketAclCreate(ctx context.Context, d *schema.ResourceData, m inte
 
 	r := service.PutBucketAcl(vpcId, s3ServiceDetail.S3ServiceId, bucketName, bucketAclRequest)
 	if !r.Status {
-		if err := d.Set("status", false); err != nil {
+		// The ACL is already the one asked for: an earlier attempt committed and
+		// only its response was lost. Record it instead of failing forever.
+		if reconcileBucketAcl(service, vpcId, s3ServiceDetail.S3ServiceId, bucketName, cannedAcl) != createAdopted {
+			if err := d.Set("status", false); err != nil {
+				return diag.Errorf("failed to create bucket ACL for bucket %s", bucketName)
+			}
 			return diag.Errorf("failed to create bucket ACL for bucket %s", bucketName)
 		}
-		return diag.Errorf("failed to create bucket ACL for bucket %s", bucketName)
 	}
 	if err := d.Set("status", true); err != nil {
 		return diag.FromErr(err)

--- a/fptcloud/object-storage/resource_bucket_cors.go
+++ b/fptcloud/object-storage/resource_bucket_cors.go
@@ -114,10 +114,18 @@ func resourceBucketCorsCreate(ctx context.Context, d *schema.ResourceData, m int
 	}
 	r := service.CreateBucketCors(vpcId, s3ServiceDetail.S3ServiceId, bucketName, payload)
 	if !r.Status {
-		if err := d.Set("status", false); err != nil {
-			return diag.FromErr(err)
+		switch reconcileCorsRule(service, vpcId, s3ServiceDetail.S3ServiceId, bucketName, jsonMap) {
+		case createAdopted:
+			// The rule is on the bucket after all: an earlier attempt committed and
+			// only its response was lost. Record it instead of failing forever.
+		case createConflict:
+			return diag.Errorf("CORS rule %q already exists on bucket %s with different settings: %s", jsonMap.ID, bucketName, r.Message)
+		default:
+			if err := d.Set("status", false); err != nil {
+				return diag.FromErr(err)
+			}
+			return diag.FromErr(fmt.Errorf("%s", r.Message))
 		}
-		return diag.FromErr(fmt.Errorf("%s", r.Message))
 	}
 	d.SetId(bucketName)
 	if err := d.Set("status", true); err != nil {
@@ -142,25 +150,56 @@ func resourceBucketCorsRead(_ context.Context, d *schema.ResourceData, m interfa
 	if !bucketCorsDetails.Status {
 		return diag.FromErr(fmt.Errorf("failed to fetch life cycle rules for bucket %s", bucketName))
 	}
-	d.SetId(bucketName)
-	var formattedData []interface{}
-	if bucketCorsDetails.Total == 0 {
-		if err := d.Set("bucket_cors_rules", make([]interface{}, 0)); err != nil {
-			d.SetId("")
-			return diag.FromErr(err)
-		}
+	ruleID, err := corsRuleID(d)
+	if err != nil {
+		return diag.FromErr(err)
 	}
+
+	// The resource owns one rule, so it is gone once its own ID is absent from the
+	// bucket's rule set - which is what happens when a rule is removed out of band
+	// or lost to a concurrent write. Clearing the ID lets Terraform plan a
+	// recreate; leaving it set strands the resource in a state no refresh can
+	// reconcile and makes the eventual destroy fail with a 404.
+	var formattedData []interface{}
+	found := false
 	for _, corsRuleDetail := range bucketCorsDetails.CorsRules {
+		if corsRuleDetail.ID == ruleID {
+			found = true
+		}
 		data := map[string]interface{}{
 			"id": corsRuleDetail.ID,
 		}
 		formattedData = append(formattedData, data)
 	}
+	if !found {
+		d.SetId("")
+		return nil
+	}
+
+	d.SetId(bucketName)
 	if err := d.Set("bucket_cors_rules", formattedData); err != nil {
 		d.SetId("")
 		return diag.FromErr(err)
 	}
 	return nil
+}
+
+// corsRuleID returns the ID of the single rule this resource manages, read from
+// whichever of the two config fields is set.
+func corsRuleID(d *schema.ResourceData) (string, error) {
+	var corsConfigData string
+	if v, ok := d.GetOk("cors_config"); ok {
+		corsConfigData = v.(string)
+	} else if v, ok := d.GetOk("cors_config_file"); ok {
+		corsConfigData = v.(string)
+	} else {
+		return "", fmt.Errorf("either 'cors_config' or 'cors_config_file' must be specified")
+	}
+	var jsonMap CorsRule
+	if err := json.Unmarshal([]byte(corsConfigData), &jsonMap); err != nil {
+		return "", err
+	}
+	return jsonMap.ID, nil
 }
 
 func resourceBucketCorsDelete(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {

--- a/fptcloud/object-storage/resource_bucket_lifecycle.go
+++ b/fptcloud/object-storage/resource_bucket_lifecycle.go
@@ -96,12 +96,66 @@ func customizeBucketLifecycleDiff(_ context.Context, d *schema.ResourceDiff, _ i
 	if jsonMap.ID == "" {
 		return fmt.Errorf("life_cycle_rule must include non-empty ID")
 	}
-	if jsonMap.Expiration.Days != 0 && jsonMap.Expiration.ExpiredObjectDeleteMarker {
+	if jsonMap.Status != "" && jsonMap.Status != lifeCycleStatusEnabled && jsonMap.Status != lifeCycleStatusDisabled {
+		return fmt.Errorf("Status must be %q or %q, got %q", lifeCycleStatusEnabled, lifeCycleStatusDisabled, jsonMap.Status)
+	}
+	if jsonMap.Expiration != nil && jsonMap.Expiration.Days != 0 && jsonMap.Expiration.ExpiredObjectDeleteMarker {
 		return fmt.Errorf("Expiration.Days and Expiration.ExpiredObjectDeleteMarker cannot be set at the same time")
 	}
 
 	return nil
 }
+
+const (
+	lifeCycleStatusEnabled  = "Enabled"
+	lifeCycleStatusDisabled = "Disabled"
+)
+
+// lifeCycleRulePayload builds the API request body, carrying only the fields the
+// rule actually declares. An omitted object is left out entirely rather than
+// sent as a zero value, which the API rejects with InvalidArgument.
+func lifeCycleRulePayload(jsonMap S3BucketLifecycleConfig) map[string]interface{} {
+	payload := map[string]interface{}{"ID": jsonMap.ID}
+	if jsonMap.Status != "" {
+		payload["Status"] = jsonMap.Status
+	}
+	if jsonMap.Filter != nil {
+		payload["Filter"] = map[string]interface{}{"Prefix": jsonMap.Filter.Prefix}
+	}
+	if jsonMap.NoncurrentVersionExpiration != nil {
+		payload["NoncurrentVersionExpiration"] = map[string]interface{}{"NoncurrentDays": jsonMap.NoncurrentVersionExpiration.NoncurrentDays}
+	}
+	if jsonMap.AbortIncompleteMultipartUpload != nil {
+		payload["AbortIncompleteMultipartUpload"] = map[string]interface{}{"DaysAfterInitiation": jsonMap.AbortIncompleteMultipartUpload.DaysAfterInitiation}
+	}
+	if jsonMap.Expiration != nil {
+		if jsonMap.Expiration.Days != 0 {
+			payload["Expiration"] = map[string]interface{}{"Days": jsonMap.Expiration.Days}
+		} else if jsonMap.Expiration.ExpiredObjectDeleteMarker {
+			payload["Expiration"] = map[string]interface{}{"ExpiredObjectDeleteMarker": true}
+		}
+	}
+	return payload
+}
+
+// lifeCycleRuleID returns the ID of the single rule this resource manages, read
+// from whichever of the two config fields is set.
+func lifeCycleRuleID(d *schema.ResourceData) (string, error) {
+	var lifecycleRuleContent string
+	if v, ok := d.GetOk("life_cycle_rule"); ok {
+		lifecycleRuleContent = v.(string)
+	} else if v, ok := d.GetOk("life_cycle_rule_file"); ok {
+		lifecycleRuleContent = v.(string)
+	} else {
+		return "", fmt.Errorf("either 'life_cycle_rule' or 'life_cycle_rule_file' must be specified")
+	}
+	jsonMap, err := parseLifeCycleData(lifecycleRuleContent)
+	if err != nil {
+		return "", err
+	}
+	return jsonMap.ID, nil
+}
+
 func parseLifeCycleData(lifeCycleData string) (S3BucketLifecycleConfig, error) {
 	var jsonMap S3BucketLifecycleConfig
 	err := json.Unmarshal([]byte(lifeCycleData), &jsonMap)
@@ -135,30 +189,30 @@ func resourceBucketLifeCycleCreate(ctx context.Context, d *schema.ResourceData, 
 	if err != nil {
 		return diag.FromErr(err)
 	}
-	payload := map[string]interface{}{
-		"ID":                             jsonMap.ID,
-		"NoncurrentVersionExpiration":    map[string]interface{}{"NoncurrentDays": jsonMap.NoncurrentVersionExpiration.NoncurrentDays},
-		"AbortIncompleteMultipartUpload": map[string]interface{}{"DaysAfterInitiation": jsonMap.AbortIncompleteMultipartUpload.DaysAfterInitiation},
-		"Filter":                         map[string]interface{}{"Prefix": jsonMap.Filter.Prefix},
-	}
-	if jsonMap.Expiration.Days != 0 && jsonMap.Expiration.ExpiredObjectDeleteMarker {
+	if jsonMap.Expiration != nil && jsonMap.Expiration.Days != 0 && jsonMap.Expiration.ExpiredObjectDeleteMarker {
 		return diag.FromErr(fmt.Errorf("Expiration.Days and Expiration.ExpiredObjectDeleteMarker cannot be set at the same time"))
 	}
-	if jsonMap.Expiration.Days != 0 {
-		payload["Expiration"] = map[string]interface{}{"Days": jsonMap.Expiration.Days}
-	}
-	if jsonMap.Expiration.ExpiredObjectDeleteMarker {
-		payload["Expiration"] = map[string]interface{}{"ExpiredObjectDeleteMarker": jsonMap.Expiration.ExpiredObjectDeleteMarker}
-	}
+	payload := lifeCycleRulePayload(jsonMap)
 	r := service.PutBucketLifecycle(vpcId, s3ServiceDetail.S3ServiceId, bucketName, payload)
-	d.SetId(bucketName)
+	// The ID is only claimed once the rule is known to exist. Returning an error
+	// with an ID set makes Terraform record the resource as tainted, so the next
+	// apply or destroy issues a delete for a rule that was never created and the
+	// backend answers 404.
 	if !r.Status {
-		if err := d.Set("state", false); err != nil {
-			d.SetId("")
-			return diag.FromErr(err)
+		switch reconcileLifeCycleRule(service, vpcId, s3ServiceDetail.S3ServiceId, bucketName, jsonMap) {
+		case createAdopted:
+			// The rule is on the bucket after all: an earlier attempt committed and
+			// only its response was lost. Record it instead of failing forever.
+		case createConflict:
+			return diag.Errorf("lifecycle rule %q already exists on bucket %s with different settings: %s", jsonMap.ID, bucketName, r.Message)
+		default:
+			if err := d.Set("state", false); err != nil {
+				return diag.FromErr(err)
+			}
+			return diag.FromErr(fmt.Errorf("%s", r.Message))
 		}
-		return diag.FromErr(fmt.Errorf("%s", r.Message))
 	}
+	d.SetId(bucketName)
 	if err := d.Set("state", true); err != nil {
 		d.SetId("")
 		return diag.FromErr(err)
@@ -183,21 +237,33 @@ func resourceBucketLifeCycleRead(_ context.Context, d *schema.ResourceData, m in
 	if !lifeCycleResponse.Status {
 		return diag.FromErr(fmt.Errorf("failed to fetch life cycle rules for bucket %s", bucketName))
 	}
-	d.SetId(bucketName)
-	var formattedData []interface{}
-	if lifeCycleResponse.Total == 0 {
-		if err := d.Set("rules", make([]interface{}, 0)); err != nil {
-			d.SetId("")
-			return diag.FromErr(err)
-		}
+	ruleID, err := lifeCycleRuleID(d)
+	if err != nil {
+		return diag.FromErr(err)
 	}
+
+	// The resource owns one rule, so it is gone once its own ID is absent from the
+	// bucket's rule set - which is what happens when a rule is removed out of band
+	// or lost to a concurrent write. Clearing the ID lets Terraform plan a
+	// recreate; leaving it set strands the resource in a state no refresh can
+	// reconcile and makes the eventual destroy fail with a 404.
+	var formattedData []interface{}
+	found := false
 	for _, lifecycleRule := range lifeCycleResponse.Rules {
+		if lifecycleRule.ID == ruleID {
+			found = true
+		}
 		data := map[string]interface{}{
 			"id": lifecycleRule.ID,
 		}
 		formattedData = append(formattedData, data)
 	}
+	if !found {
+		d.SetId("")
+		return nil
+	}
 
+	d.SetId(bucketName)
 	if err := d.Set("rules", formattedData); err != nil {
 		d.SetId("")
 		return diag.FromErr(err)
@@ -229,23 +295,11 @@ func resourceBucketLifeCycleDelete(ctx context.Context, d *schema.ResourceData, 
 		return diag.FromErr(err)
 	}
 
-	payload := map[string]interface{}{
-		"AbortIncompleteMultipartUpload": map[string]interface{}{"DaysAfterInitiation": jsonMap.AbortIncompleteMultipartUpload.DaysAfterInitiation},
-		"Status":                         "Enabled",
-		"ID":                             jsonMap.ID,
-		"OrgID":                          jsonMap.ID, // Portal need both ID and OrgID
-		"Filter":                         map[string]interface{}{"Prefix": jsonMap.Filter.Prefix},
-		"NoncurrentVersionExpiration":    map[string]interface{}{"NoncurrentDays": jsonMap.NoncurrentVersionExpiration.NoncurrentDays},
-	}
-	if jsonMap.Expiration.Days != 0 && jsonMap.Expiration.ExpiredObjectDeleteMarker {
+	if jsonMap.Expiration != nil && jsonMap.Expiration.Days != 0 && jsonMap.Expiration.ExpiredObjectDeleteMarker {
 		return diag.FromErr(fmt.Errorf("Expiration.Days and Expiration.ExpiredObjectDeleteMarker cannot be set at the same time"))
 	}
-	if jsonMap.Expiration.Days != 0 {
-		payload["Expiration"] = map[string]interface{}{"Days": jsonMap.Expiration.Days}
-	}
-	if jsonMap.Expiration.ExpiredObjectDeleteMarker {
-		payload["Expiration"] = map[string]interface{}{"ExpiredObjectDeleteMarker": jsonMap.Expiration.ExpiredObjectDeleteMarker}
-	}
+	payload := lifeCycleRulePayload(jsonMap)
+	payload["OrgID"] = jsonMap.ID // Portal need both ID and OrgID
 	r := service.DeleteBucketLifecycle(vpcId, s3ServiceDetail.S3ServiceId, bucketName, payload)
 	if !r.Status {
 		if err := d.Set("state", false); err != nil {

--- a/fptcloud/object-storage/resource_bucket_policy.go
+++ b/fptcloud/object-storage/resource_bucket_policy.go
@@ -98,10 +98,18 @@ func resourceBucketPolicyCreate(ctx context.Context, d *schema.ResourceData, m i
 	resp := service.PutBucketPolicy(vpcId, s3ServiceDetail.S3ServiceId, bucketName, payload)
 
 	if !resp.Status {
-		if err := d.Set("status", false); err != nil {
-			return diag.Errorf("failed to create bucket policy: %s", resp.Message)
+		switch reconcileBucketPolicy(service, vpcId, s3ServiceDetail.S3ServiceId, bucketName, policyContent) {
+		case createAdopted:
+			// The policy is in place after all: an earlier attempt committed and only
+			// its response was lost. Record it instead of failing forever.
+		case createConflict:
+			return diag.Errorf("bucket %s already carries a different policy: %s", bucketName, resp.Message)
+		default:
+			if err := d.Set("status", false); err != nil {
+				return diag.Errorf("failed to create bucket policy: %s", resp.Message)
+			}
+			return diag.FromErr(fmt.Errorf("error create bucket policy: %s", resp.Message))
 		}
-		return diag.FromErr(fmt.Errorf("error create bucket policy: %s", resp.Message))
 	}
 	d.SetId(bucketName)
 	if err := d.Set("status", true); err != nil {

--- a/fptcloud/object-storage/resource_bucket_static_website.go
+++ b/fptcloud/object-storage/resource_bucket_static_website.go
@@ -80,14 +80,20 @@ func resourceBucketStaticWebsiteCreate(ctx context.Context, d *schema.ResourceDa
 		Suffix: indexDocument,
 		Key:    errorDocument,
 	})
-	d.SetId(bucketName)
+	// A failed call has to surface as an error and leave the ID empty. Returning
+	// nil here reported a website configuration that was never created as a
+	// successful apply, and an ID set on the error path would strand it in state.
 	if !putBucketWebsite.Status {
-		if err := d.Set("status", false); err != nil {
-			d.SetId("")
+		// A website configuration is present after all: an earlier attempt committed
+		// and only its response was lost. Record it instead of failing forever.
+		if reconcileBucketWebsite(service, vpcId, s3ServiceDetail.S3ServiceId, bucketName) != createAdopted {
+			if err := d.Set("status", false); err != nil {
+				return diag.FromErr(err)
+			}
 			return diag.Errorf("failed to create bucket website for bucket %s", bucketName)
 		}
-		return nil
 	}
+	d.SetId(bucketName)
 	if err := d.Set("status", true); err != nil {
 		d.SetId("")
 		return diag.FromErr(err)

--- a/fptcloud/object-storage/resource_bucket_versioning.go
+++ b/fptcloud/object-storage/resource_bucket_versioning.go
@@ -63,7 +63,11 @@ func resourceBucketVersioningCreate(ctx context.Context, d *schema.ResourceData,
 	})
 
 	if err != nil {
-		return diag.FromErr(err)
+		// The setting is already the one asked for: an earlier attempt committed and
+		// only its response was lost. Record it instead of failing forever.
+		if reconcileBucketVersioning(service, vpcId, s3ServiceDetail.S3ServiceId, bucketName, versioningStatus) != createAdopted {
+			return diag.FromErr(err)
+		}
 	}
 	d.SetId(fmt.Sprintf("%s:%s", bucketName, versioningStatus))
 	if err := d.Set("versioning_status", versioningStatus); err != nil {

--- a/fptcloud/object-storage/resource_sub_user.go
+++ b/fptcloud/object-storage/resource_sub_user.go
@@ -78,7 +78,15 @@ func resourceSubUserCreate(ctx context.Context, d *schema.ResourceData, m interf
 
 	err := objectStorageService.CreateSubUser(req, vpcId, s3ServiceDetail.S3ServiceId)
 	if !err.Status {
-		return diag.FromErr(fmt.Errorf("error creating sub-user: %s", err.Message))
+		switch reconcileSubUser(objectStorageService, vpcId, s3ServiceDetail.S3ServiceId, subUserId, req.Role) {
+		case createAdopted:
+			// The sub-user exists with the requested role: an earlier attempt committed
+			// and only its response was lost. Record it instead of failing forever.
+		case createConflict:
+			return diag.Errorf("sub-user %s already exists with a different role: %s", subUserId, err.Message)
+		default:
+			return diag.FromErr(fmt.Errorf("error creating sub-user: %s", err.Message))
+		}
 	}
 
 	// Set the resource ID after successful creation


### PR DESCRIPTION
- Fix: send only the fields a lifecycle rule declares, instead of omitted objects as zero values the API rejects
- Fix: do not record a bucket lifecycle rule in state when its create fails
- Fix: detect lifecycle and CORS rules deleted outside Terraform instead of reporting them as present
- Fix: treat a missing bucket as drift instead of failing the plan
- Fix: report a failed bucket static website create as an error instead of success
- Fix: adopt object storage objects left behind by a create whose response was lost